### PR TITLE
[WiP] Enabling monitoring on container start and stopping it on container stop

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -37,6 +37,7 @@ import (
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/machine"
+	"github.com/google/cadvisor/perf"
 	"github.com/google/cadvisor/utils/oomparser"
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/version"
@@ -1120,12 +1121,14 @@ func (self *manager) watchForNewContainers(quit chan error) error {
 			case event := <-self.eventsChannel:
 				switch {
 				case event.EventType == watcher.ContainerAdd:
+					perf.StartMonitoring(event)
 					switch event.WatchSource {
 					default:
 						err = self.createContainer(event.Name, event.WatchSource)
 					}
 				case event.EventType == watcher.ContainerDelete:
 					err = self.destroyContainer(event.Name)
+					perf.StopMonitoring(event)
 				}
 				if err != nil {
 					klog.Warningf("Failed to process watch event %+v: %v", event, err)

--- a/perf/monitoring.go
+++ b/perf/monitoring.go
@@ -1,0 +1,39 @@
+package perf
+
+import (
+	"github.com/google/cadvisor/watcher"
+	"k8s.io/klog"
+)
+
+// StartMonitoring sets perf events up for a container.
+func StartMonitoring(event watcher.ContainerEvent) {
+	klog.Infof("starting monitoring for %#v", event.Name)
+	if shouldIMonitor() {
+		// Do whatever needs to be done in order to monitor all
+		// the necessary events.
+		// Launch a goroutine responsible for reading events' values.
+		// Read from configuration (I do not know how it would be 
+		// encoded) and set only requested events up.
+	}
+}
+
+func shouldIMonitor() bool {
+	// I assume that we are not going to monitor all the containers. 
+	// We need to be able to choose them somehow and configuration 
+	// with have to be available here.
+	return true
+}
+
+// StopMonitoring tears perf evets down for container.
+func StopMonitoring(event watcher.ContainerEvent) {
+	klog.Infof("stopping monitoring for %#v", event.Name)
+	if isMonitored() {
+		// Close file descriptors, gracefully stop all gouroutines
+		// make sure that final values for events are collected.
+	}
+}
+
+func isMonitored() bool {
+	// We do not want to close non-existing file descriptors etc.
+	return true
+}


### PR DESCRIPTION
Enabling perf events on container start or discovery and disabling them on container stop. 
This is **very** rough attempt at identifying how it can be achieved (multiple calls are triggered for each container started).